### PR TITLE
chore: Run clippy with `--all-targets` via CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,4 +38,4 @@ jobs:
         run: cargo test
 
       - name: Clippy
-        run: cargo clippy
+        run: cargo clippy --all-targets


### PR DESCRIPTION
Ensures tests get proper linting.