### PR TITLE
chore: Refactor for readability

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,9 +186,6 @@ where
             // using exit codes as the only way to communicate errors.
             // TODO: Get rid of all of the .expect()s
 
-            // Droping the writer will close the write_fd, so we take it early
-            // and explicitly to prevent use after free with two unsafe codes
-            // scattered around the child code below.
             let mut writer = unsafe { File::from_raw_fd(write_fd) };
             close_read_end_of_pipe_in_child_or_exit(&sys, &mut writer, read_fd);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,6 @@ const CHILD_EXIT_IF_WRITE_FAILED: i32 = 4;
 /// This is the intended behavior as the function's purpose is to isolate all
 /// memory effects of the callable. However, this can be surprising, especially
 /// for [`FnMut`] or [`FnOnce`] closures.
-#[allow(clippy::missing_panics_doc)] // We have to panic in the child process but clippy can't tell this is OK
 #[allow(clippy::too_many_lines)] // TODO: Break this up for readability
 pub fn execute_in_isolated_process<F, T>(callable: F) -> Result<T, MemIsolateError>
 where


### PR DESCRIPTION
This change greatly improves the readability of `execute_in_isolated_process()`.