### PR TITLE
feat: Add `tracing` feature

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.cargo.features": ["full"]
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +292,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "mem-isolate"
 version = "0.1.1"
 dependencies = [
@@ -296,6 +311,8 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -303,6 +320,16 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-traits"
@@ -324,6 +351,18 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "plotters"
@@ -438,8 +477,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -450,8 +498,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -526,6 +580,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+
+[[package]]
 name = "syn"
 version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +640,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,10 +660,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "walkdir"
@@ -674,6 +820,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +843,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,16 @@ readme = "README.md"
 repository = "https://github.com/brannondorsey/mem-isolate"
 keywords = ["memory", "isolation", "sandbox", "unix"]
 categories = ["memory-management", "os::unix-apis", "rust-patterns"]
-exclude = [
-    ".github/*",
-]
+exclude = [".github/*"]
 
 [features]
+# Include no features by default
+default = []
+
+# Include all features
+full = ["tracing"]
+
+# Actual features
 tracing = ["dep:tracing"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,16 +13,21 @@ exclude = [
     ".github/*",
 ]
 
+[features]
+tracing = ["dep:tracing"]
+
 [dependencies]
 bincode = "1"
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
+tracing = { version = "0.1.41", optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
 rand = "0.9.0"
 tempfile = "3.18.0"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 [[bench]]
 name = "benchmarks"
@@ -35,3 +40,7 @@ test = true
 [[example]]
 name = "error-handling-complete"
 test = true
+
+[[example]]
+name = "tracing"
+required-features = ["tracing"]

--- a/examples/tracing.rs
+++ b/examples/tracing.rs
@@ -1,0 +1,23 @@
+// Compile error if tracing is not enabled
+#[cfg(feature = "tracing")]
+use tracing::{info, instrument};
+#[cfg(not(feature = "tracing"))]
+compile_error!(
+    "This example requires the 'tracing' feature to be enabled. Run with: cargo run --example tracing --features tracing"
+);
+
+use mem_isolate::MemIsolateError;
+#[cfg_attr(feature = "tracing", instrument)]
+fn main() -> Result<(), MemIsolateError> {
+    #[cfg(feature = "tracing")]
+    {
+        // TODO: Make sure RUST_LOG is overriding the default
+        tracing_subscriber::fmt().with_env_filter("trace").init();
+        mem_isolate::execute_in_isolated_process(|| {
+            info!("look ma, I'm in the callable!");
+            42
+        })?;
+    }
+
+    Ok(())
+}

--- a/examples/tracing.rs
+++ b/examples/tracing.rs
@@ -1,23 +1,29 @@
 // Compile error if tracing is not enabled
-#[cfg(feature = "tracing")]
-use tracing::{info, instrument};
 #[cfg(not(feature = "tracing"))]
 compile_error!(
     "This example requires the 'tracing' feature to be enabled. Run with: cargo run --example tracing --features tracing"
 );
 
 use mem_isolate::MemIsolateError;
-#[cfg_attr(feature = "tracing", instrument)]
+use tracing::{Level, info, instrument};
+use tracing_subscriber::EnvFilter;
+
+#[instrument]
 fn main() -> Result<(), MemIsolateError> {
-    #[cfg(feature = "tracing")]
-    {
-        // TODO: Make sure RUST_LOG is overriding the default
-        tracing_subscriber::fmt().with_env_filter("trace").init();
-        mem_isolate::execute_in_isolated_process(|| {
-            info!("look ma, I'm in the callable!");
-            42
-        })?;
-    }
+    init_tracing_subscriber();
+
+    mem_isolate::execute_in_isolated_process(|| {
+        info!("look ma, I'm in the callable!");
+        42
+    })?;
 
     Ok(())
+}
+
+/// Defaults to TRACE but can be overridden by the RUST_LOG environment variable
+fn init_tracing_subscriber() {
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(Level::TRACE.into())
+        .from_env_lossy();
+    tracing_subscriber::fmt().with_env_filter(env_filter).init();
 }

--- a/src/c.rs
+++ b/src/c.rs
@@ -18,7 +18,7 @@ pub struct PipeFds {
 }
 
 // Define the core trait for system functions
-pub trait SystemFunctions {
+pub trait SystemFunctions: std::fmt::Debug {
     fn fork(&self) -> Result<ForkReturn, io::Error>;
     fn pipe(&self) -> Result<PipeFds, io::Error>;
     fn close(&self, fd: c_int) -> Result<(), io::Error>;

--- a/src/c/mock.rs
+++ b/src/c/mock.rs
@@ -6,7 +6,7 @@ use std::io;
 use std::thread_local;
 
 // Type for representing a mock result
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum MockResult<T> {
     Ok(T),
     Err(i32), // OS error code
@@ -37,7 +37,7 @@ impl<T> MockResult<T> {
 }
 
 /// Defines how a call should be implemented - real or mocked
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum CallImplementation<T> {
     Real,                // Use real implementation
     Mock(MockResult<T>), // Use mocked result
@@ -50,7 +50,7 @@ pub enum CallBehavior<T> {
 }
 
 /// A generic queue of call implementations
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct CallQueue<T> {
     queue: RefCell<VecDeque<CallImplementation<T>>>,
     name: &'static str, // For better error messages
@@ -93,7 +93,7 @@ impl<T: Clone> CallQueue<T> {
 }
 
 /// Mock implementation that returns predefined values and can fall back to real implementation
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MockableSystemFunctions {
     real_impl: RealSystemFunctions,
     fallback_enabled: Cell<bool>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,6 @@ where
             exit_happy(&sys)
         }
 
-        // TODO: Pick back up here and finish tracing the parent process
         // Parent process
         Ok(ForkReturn::Parent(child_pid)) => {
             close_write_end_of_pipe_in_parent(&sys, write_fd)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 //! # `mem-isolate`: *Run unsafe code safely*
 //!
-//! It runs your function via a `fork()`, waits for the result, and
-//! returns it.
+//! It runs your function via a `fork()`, waits for the result, and returns it.
 //!
 //! This grants your code access to an exact copy of memory and state at the
 //! time just before the call, but guarantees that the function will not affect
@@ -32,12 +31,28 @@
 //!
 //! For more information, see the [README](https://github.com/brannondorsey/mem-isolate).
 //!
-//! ## Supported platforms
+//! ## Supported Platforms
 //!
 //! Because of its heavy use of POSIX system calls, this crate only
 //! supports Unix-like operating systems (e.g. Linux, macOS, BSD).
 //!
 //! Windows and wasm support are not planned at this time.
+//!
+//!
+//! ## Feature Flags
+//!
+//! The following crate [feature
+//! flags](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section)
+//! are available:
+//!
+//! * `tracing`: Enable [tracing](https://docs.rs/tracing) instrumentation.
+//!   Instruments all high-level functions in [`lib.rs`](https://github.com/brannondorsey/mem-isolate/blob/main/src/lib.rs) and creates spans for
+//!   child and parent processes in [`execute_in_isolated_process`]. Events are
+//!   mostly `debug!` and `error!` level. See [`examples/tracing.rs`](https://github.com/brannondorsey/mem-isolate/blob/main/examples/tracing.rs)
+//!   for an example.
+//!
+//! By default, no additional features are enabled.
+//!
 #![warn(missing_docs)]
 #![warn(clippy::pedantic, clippy::unwrap_used)]
 #![warn(missing_debug_implementations)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,69 @@
+//! Private macros module for conditional tracing
+//!
+//! This module provides macros that simplify conditional tracing by
+//! squashing the two-line pattern:
+//!
+//! ```
+//! #[cfg(feature = "tracing")]
+//! tracing::debug!("message", args);
+//! ```
+//!
+//! Into a `debug!` macro call.
+//!
+//! These macros have the same names as the tracing crate's macros,
+//! but they are conditionally compiled based on the "tracing" feature.
+#![allow(unused_imports)]
+#![allow(unused_macros)]
+
+/// Conditionally emits a trace-level log message when the "tracing" feature is enabled.
+///
+/// This macro does nothing when the "tracing" feature is disabled.
+#[macro_export]
+macro_rules! trace {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "tracing")]
+        tracing::trace!($($arg)*);
+    };
+}
+
+/// Conditionally emits a debug-level log message when the "tracing" feature is enabled.
+///
+/// This macro does nothing when the "tracing" feature is disabled.
+macro_rules! debug {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "tracing")]
+        tracing::debug!($($arg)*);
+    };
+}
+
+/// Conditionally emits an info-level log message when the "tracing" feature is enabled.
+///
+/// This macro does nothing when the "tracing" feature is disabled.
+macro_rules! info {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "tracing")]
+        tracing::info!($($arg)*);
+    };
+}
+
+/// Conditionally emits a warn-level log message when the "tracing" feature is enabled.
+///
+/// This macro does nothing when the "tracing" feature is disabled.
+macro_rules! warning {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "tracing")]
+        tracing::warn!($($arg)*);
+    };
+}
+
+/// Conditionally emits an error-level log message when the "tracing" feature is enabled.
+///
+/// This macro does nothing when the "tracing" feature is disabled.
+macro_rules! error {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "tracing")]
+        tracing::error!($($arg)*);
+    };
+}
+
+pub(crate) use {debug, error, info, trace, warning};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -5,7 +5,7 @@
 //!
 //! ```
 //! #[cfg(feature = "tracing")]
-//! tracing::debug!("message", args);
+//! tracing::debug!("message");
 //! ```
 //!
 //! Into a `debug!` macro call.


### PR DESCRIPTION
Instruments detailed tracing, configurable as a feature. Closes #17.

## Todo

* [x] Document tracing feature
* [x] DRY it out (probably with our own macros)
* [x] Add `examples/tracing.rs`
* [x] Respect `RUST_LOG` in example