### PR TITLE
docs: Clarify function purity definition in README and module description

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 `mem-isolate` runs your function via a `fork()`, waits for the result, and returns it.
 
-This grants your code access to an exact copy of memory and state at the time just before the call, but guarantees that the function will not affect the parent process's memory footprint in any way. It forces functions to be *pure*, even if they aren't.
+This grants your code access to an exact copy of memory and state at the time just before the call, but guarantees that the function will not affect the parent process's memory footprint in any way.
+
+It forces functions to be *memory pure* (pure with respect to memory), even if they aren't.
 
 ```rust
 use mem_isolate::execute_in_isolated_process;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,10 @@
 //!
 //! This grants your code access to an exact copy of memory and state at the
 //! time just before the call, but guarantees that the function will not affect
-//! the parent process's memory footprint in any way. It forces functions to be
-//! *pure*, even if they aren't.
+//! the parent process's memory footprint in any way.
+//!
+//! It forces functions to be *memory pure* (pure with respect to memory), even
+//! if they aren't.
 //!
 //! ```
 //! use mem_isolate::execute_in_isolated_process;


### PR DESCRIPTION
This was good feedback from @RikHeijdens.
