### PR TITLE
chore: Cut a new release only when the release PR is merged

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,4 @@
+[workspace]
+# Release only when release PR is merged
+# https://release-plz.dev/docs/config#the-release_always-field
+release_always = false


### PR DESCRIPTION
Not on every merge to `main`.