### PR TITLE
fix: Handle syscall interruption by retrying `EINTR` errors encountered during `waitpid()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,6 +305,7 @@ fn wait_for_child<S: SystemFunctions>(
     sys: &S,
     child_pid: c_int,
 ) -> Result<WaitpidStatus, MemIsolateError> {
+    debug!("waiting for child process");
     let waitpid_bespoke_status = loop {
         match sys.waitpid(child_pid) {
             Ok(status) => break status,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -37,6 +37,10 @@ fn error_enfile() -> io::Error {
     io::Error::from_raw_os_error(libc::ENFILE)
 }
 
+fn error_eintr() -> io::Error {
+    io::Error::from_raw_os_error(libc::EINTR)
+}
+
 fn write_pid_to_file(path: &Path) -> io::Result<()> {
     let pid: u32 = process::id();
     fs::write(path, format!("{pid}\n"))
@@ -540,4 +544,23 @@ fn waitpid_child_killed_by_signal_after_suspension_and_continuation() {
             CallableStatusUnknownError::ChildProcessKilledBySignal(libc::SIGKILL)
         ))
     ));
+}
+
+#[test]
+fn waitpid_interrupted_by_signal() {
+    with_mock_system(
+        configured_with_fallback(|mock| {
+            // waitpid() will return EINTR if a signal is delivered to the parent,
+            // we want to continue in this case. Here we mock the first three calls to
+            // waitpid() returning EINTR, then the fourth call will fallback to the
+            // real syscall.
+            mock.expect_waitpid(CallBehavior::Mock(Err(error_eintr())));
+            mock.expect_waitpid(CallBehavior::Mock(Err(error_eintr())));
+            mock.expect_waitpid(CallBehavior::Mock(Err(error_eintr())));
+        }),
+        |_| {
+            let result = execute_in_isolated_process(|| MyResult { value: 42 });
+            assert_eq!(result.unwrap(), MyResult { value: 42 });
+        },
+    );
 }


### PR DESCRIPTION
If the parent process receives a signal while the child process is executing, we shouldn't fail with `CallableStatusUnknown(WaitFailed(wait_err))`. Instead, we should ignore the `EINTR` and keep waiting.

Closes https://github.com/users/brannondorsey/projects/5?pane=issue&itemId=103700825&issue=brannondorsey%7Cmem-isolate%7C33.