### PR TITLE
docs: Add examples illustrating how to block and restore signals around mem-isolate calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +345,7 @@ dependencies = [
  "criterion",
  "ctor",
  "libc",
+ "nix",
  "rand",
  "serde",
  "tempfile",
@@ -352,6 +359,18 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nu-ansi-term"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tracing = { version = "0.1.41", optional = true }
 [dev-dependencies]
 criterion = "0.5.1"
 ctor = "0.4.1"
+nix = { version = "0.29.0", features = ["signal"] }
 rand = "0.9.0"
 tempfile = "3.18.0"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/examples/blocking-signals-demonstration.rs
+++ b/examples/blocking-signals-demonstration.rs
@@ -4,7 +4,7 @@
 //! This is useful if:
 //!
 //! 1. You want to simulate the expected behavior of running your code without
-//!    `mem_isolate::execute_in_isolated_process()`, which would be gauranteed
+//!    `mem_isolate::execute_in_isolated_process()`, which would be guaranteed
 //!    to treat signals the same both inside and outside of the `callable()`
 //!    function.
 //! 2. You want to prevent either process from being interrupted by signals
@@ -23,6 +23,10 @@
 //!
 //! NOTE: Because both SIGKILL and SIGSTOP are unblockable, nothing can be done
 //! to prevent them from killing the parent process or the child process.
+//!
+//! WARNING: Do not expect signal handling to work as you might think in a
+//! multi-threaded program. It is not recommended to use `mem_isolate` in a
+//! multi-threaded program anyway, so that's generally OK.
 
 use mem_isolate::{MemIsolateError, execute_in_isolated_process};
 use nix::errno::Errno;

--- a/examples/blocking-signals-demonstration.rs
+++ b/examples/blocking-signals-demonstration.rs
@@ -1,3 +1,11 @@
+//! This example demonstrates how to block signals in a parent process while
+//! executing code in an isolated process.
+//!
+//! This is useful if you want to ensure that the parent process is not killed
+//! while the isolated process is running. This example is great for illustrating
+//! how signal blocking works, but if you want to just copy and paste some code,
+//! see `blocking-signals-minimal.rs`
+
 use mem_isolate::{MemIsolateError, execute_in_isolated_process};
 use nix::errno::Errno;
 use nix::sys::signal::{SigSet, SigmaskHow, sigprocmask};
@@ -15,7 +23,7 @@ fn main() -> Result<(), MemIsolateError> {
     let (block_signals, restore_signals) = get_block_and_restore_signal_closures();
 
     // Block all signals right before calling `mem_isolate::execute_in_isolated_process()`
-    println!("Parent: blocking all signals");
+    println!("Parent: Blocking all signals");
     block_signals().expect("Failed to block signals");
 
     // Kick-off a subprocess that will send a SIGTERM to this process
@@ -38,7 +46,7 @@ fn main() -> Result<(), MemIsolateError> {
         wait_time_for_readability.as_secs()
     );
     thread::sleep(wait_time_for_readability);
-    println!("Parent: restoring signals, expect the parent to now recieve the SIGTERM");
+    println!("Parent: Restoring signals, expect the parent to now recieve the SIGTERM");
     restore_signals().expect("Failed to restore signals");
     // WARNING: Don't expect code to ever reach this point, because the pending SIGTERM will kill the parent process
     // as soon as we unblock the SIGTERM that has been pending this whole time

--- a/examples/blocking-signals-minimal.rs
+++ b/examples/blocking-signals-minimal.rs
@@ -1,0 +1,42 @@
+//! See `blocking-signals-demonstration.rs` for a more detailed example of
+//! how signal blocking works at runtime.
+//!
+//! Use this example for copy + paste code snippets.
+
+use mem_isolate::{MemIsolateError, execute_in_isolated_process};
+use nix::errno::Errno;
+use nix::sys::signal::{SigSet, SigmaskHow, sigprocmask};
+
+fn main() -> Result<(), MemIsolateError> {
+    // Block all signals right before calling `mem_isolate::execute_in_isolated_process()`
+    // This ensures the main program won't be killed leaving an orphaned child process
+    let (block_signals, restore_signals) = get_block_and_restore_signal_closures();
+    block_signals().expect("Failed to block signals");
+
+    // Run your code in an isolated process
+    let result = execute_in_isolated_process(|| ());
+
+    // Restore the signal mask
+    restore_signals().expect("Failed to restore signals");
+    result
+}
+
+fn get_block_and_restore_signal_closures() -> (
+    impl FnOnce() -> Result<(), Errno>,
+    impl FnOnce() -> Result<(), Errno>,
+) {
+    let all_signals = SigSet::all();
+    let mut old_signals = SigSet::empty();
+
+    let block_signals = move || {
+        sigprocmask(
+            SigmaskHow::SIG_SETMASK,
+            Some(&all_signals),
+            Some(&mut old_signals),
+        )
+    };
+
+    let restore_signals = move || sigprocmask(SigmaskHow::SIG_SETMASK, Some(&old_signals), None);
+
+    (block_signals, restore_signals)
+}

--- a/examples/blocking-signals-minimal.rs
+++ b/examples/blocking-signals-minimal.rs
@@ -1,5 +1,5 @@
 //! See `blocking-signals-demonstration.rs` for a more detailed example of
-//! how signal blocking works at runtime.
+//! how signal blocking works at runtime, and why you might want to do it.
 //!
 //! Use this example for copy + paste code snippets.
 
@@ -13,10 +13,12 @@ fn main() -> Result<(), MemIsolateError> {
     let (block_signals, restore_signals) = get_block_and_restore_signal_closures();
     block_signals().expect("Failed to block signals");
 
-    // Run your code in an isolated process
+    // Run your code in an isolated process. NOTE: The child process created by
+    // `fork()` inside `execute_in_isolated_process()` will inherit the signal
+    // mask set by main process just above.
     let result = execute_in_isolated_process(|| ());
 
-    // Restore the signal mask
+    // Restore the signal mask, unblocking all signals
     restore_signals().expect("Failed to restore signals");
     result
 }

--- a/examples/blocking-signals.rs
+++ b/examples/blocking-signals.rs
@@ -1,39 +1,48 @@
 use mem_isolate::{MemIsolateError, execute_in_isolated_process};
 use nix::errno::Errno;
-use nix::sys::signal::{SigSet, SigmaskHow, kill, sigprocmask};
+use nix::sys::signal::{SigSet, SigmaskHow, sigprocmask};
 use nix::unistd::Pid;
+use std::process::{Child, Command, Stdio};
 use std::thread;
 use std::time::Duration;
 
 fn main() -> Result<(), MemIsolateError> {
     let parent_pid = Pid::this();
-    let dramatic_pause = Duration::from_secs(1);
+    println!("Parent PID: {}", parent_pid);
+    let wait_time_for_readability = Duration::from_secs(5);
 
+    // Get closures for blocking and restoring signals
     let (block_signals, restore_signals) = get_block_and_restore_signal_closures();
-    println!("Parent: blocking signals\n");
+
+    // Block all signals right before calling `mem_isolate::execute_in_isolated_process()`
+    println!("Parent: blocking all signals");
     block_signals().expect("Failed to block signals");
 
+    // Kick-off a subprocess that will send a SIGTERM to this process
+    let sigterm_sender_proc = send_sigterm_to_parent(Duration::from_secs(1));
+
+    // Execute the user-defined callable in an isolated process
     let result = execute_in_isolated_process(move || {
-        // Don't try this at home, kids
-        println!("Child: I'm a nasty lil' bugger, and I'm going to send a SIGTERM to my parent");
-        thread::sleep(dramatic_pause); // Pause for dramatic effect
-        kill(parent_pid, nix::sys::signal::Signal::SIGTERM)
-            .expect("Failed to send SIGTERM from the child");
-        println!("Child: SIGTERM sent to parent");
-        thread::sleep(dramatic_pause); // Pause for dramatic effect
+        println!(
+            "\nChild: I've started executing a user-defined callable. I'll wait for {} seconds before exiting...",
+            wait_time_for_readability.as_secs()
+        );
+        thread::sleep(wait_time_for_readability);
         println!("Child: I'm all done now, exiting\n");
     });
 
-    println!("Parent: restoring signals in...");
-    println!("Parent: 3...");
-    thread::sleep(dramatic_pause);
-    println!("Parent: 2...");
-    thread::sleep(dramatic_pause);
-    println!("Parent: 1...");
-    thread::sleep(dramatic_pause);
-    println!("Parent: restoring signals");
+    reap_child_process_so_it_doesnt_become_a_zombie(sigterm_sender_proc);
+
+    println!(
+        "Parent: Notice that the SIGTERM is pending and didn't interrupt this process or the child process. Unblocking signals in {} seconds...",
+        wait_time_for_readability.as_secs()
+    );
+    thread::sleep(wait_time_for_readability);
+    println!("Parent: restoring signals, expect the parent to now recieve the SIGTERM");
     restore_signals().expect("Failed to restore signals");
-    println!("Parent: Notice that I never make it here, because the pending SIGTERM did me in");
+    // WARNING: Don't expect code to ever reach this point, because the pending SIGTERM will kill the parent process
+    // as soon as we unblock the SIGTERM that has been pending this whole time
+
     result
 }
 
@@ -55,4 +64,32 @@ fn get_block_and_restore_signal_closures() -> (
     let restore_signals = move || sigprocmask(SigmaskHow::SIG_SETMASK, Some(&old_signals), None);
 
     (block_signals, restore_signals)
+}
+
+fn send_sigterm_to_parent(wait_time: Duration) -> Child {
+    // We do this via a subprocess instead of a thread because the latter will
+    // break the signal mask that we have set. `mem_isolate::execute_in_isolated_process()`
+    // also SHOULD NOT be used in a multi-threaded program (see limitations in README)
+    println!(
+        "Parent: Sending SIGTERM to self in {} seconds. NOTE: This signal will be sent to the parent while the child is executing the user-defined callable",
+        wait_time.as_secs()
+    );
+    Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            "sleep {} && kill -s TERM {}",
+            wait_time.as_secs(),
+            Pid::this()
+        ))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("Failed to spawn delayed kill command")
+}
+
+fn reap_child_process_so_it_doesnt_become_a_zombie(mut child: Child) {
+    let exit_status = child.wait().expect("Failed to wait for child process");
+    if !exit_status.success() {
+        panic!("Other process: failed to send SIGTERM to parent process");
+    }
 }

--- a/examples/blocking-signals.rs
+++ b/examples/blocking-signals.rs
@@ -1,0 +1,58 @@
+use mem_isolate::{MemIsolateError, execute_in_isolated_process};
+use nix::errno::Errno;
+use nix::sys::signal::{SigSet, SigmaskHow, kill, sigprocmask};
+use nix::unistd::Pid;
+use std::thread;
+use std::time::Duration;
+
+fn main() -> Result<(), MemIsolateError> {
+    let parent_pid = Pid::this();
+    let dramatic_pause = Duration::from_secs(1);
+
+    let (block_signals, restore_signals) = get_block_and_restore_signal_closures();
+    println!("Parent: blocking signals\n");
+    block_signals().expect("Failed to block signals");
+
+    let result = execute_in_isolated_process(move || {
+        // Don't try this at home, kids
+        println!("Child: I'm a nasty lil' bugger, and I'm going to send a SIGTERM to my parent");
+        thread::sleep(dramatic_pause); // Pause for dramatic effect
+        kill(parent_pid, nix::sys::signal::Signal::SIGTERM)
+            .expect("Failed to send SIGTERM from the child");
+        println!("Child: SIGTERM sent to parent");
+        thread::sleep(dramatic_pause); // Pause for dramatic effect
+        println!("Child: I'm all done now, exiting\n");
+    });
+
+    println!("Parent: restoring signals in...");
+    println!("Parent: 3...");
+    thread::sleep(dramatic_pause);
+    println!("Parent: 2...");
+    thread::sleep(dramatic_pause);
+    println!("Parent: 1...");
+    thread::sleep(dramatic_pause);
+    println!("Parent: restoring signals");
+    restore_signals().expect("Failed to restore signals");
+    println!("Parent: Notice that I never make it here, because the pending SIGTERM did me in");
+    result
+}
+
+fn get_block_and_restore_signal_closures() -> (
+    impl FnOnce() -> Result<(), Errno>,
+    impl FnOnce() -> Result<(), Errno>,
+) {
+    let all_signals = SigSet::all();
+    let mut old_signals = SigSet::empty();
+
+    let block_signals = move || {
+        sigprocmask(
+            SigmaskHow::SIG_SETMASK,
+            Some(&all_signals),
+            Some(&mut old_signals),
+        )
+    };
+
+    let restore_signals = move || sigprocmask(SigmaskHow::SIG_SETMASK, Some(&old_signals), None);
+
+    (block_signals, restore_signals)
+}


### PR DESCRIPTION
Todos

* [x] Basic example
* [x] Refine the example
  * [x] consider sending the SIGTERM from a parent ~~thread~~ process to avoid confusion
  * [x] Elaborate on why this is desirable in code comments
* [ ] ~~Link it from the README's limitations section~~ We'll do this in #42 