### PR TITLE
Ensure large results are handled correctly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -431,6 +431,7 @@ fn wait_for_child<S: SystemFunctions>(
 fn error_if_child_unhappy(waitpid_bespoke_status: WaitpidStatus) -> Result<(), MemIsolateError> {
     let result = if let Some(exit_status) = child_process_exited_on_its_own(waitpid_bespoke_status)
     {
+        debug!("child process exited with status: {}", exit_status);
         match exit_status {
             CHILD_EXIT_HAPPY => Ok(()),
             CHILD_EXIT_IF_READ_CLOSE_FAILED => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,7 @@ where
             // Defer the buffer emptiness check until after the waitpid to preserve
             // the behavior that child processes that panic will result in a
             // CallableProcessDiedDuringExecution error.
-            check_buffer_is_not_empty(&buffer)?;
+            error_if_buffer_is_empty(&buffer)?;
             deserialize_result(&buffer)
         }
     }
@@ -570,7 +570,7 @@ fn read_all_of_child_result_pipe(read_fd: c_int) -> Result<Vec<u8>, MemIsolateEr
 }
 
 #[cfg_attr(feature = "tracing", instrument)]
-fn check_buffer_is_not_empty(buffer: &[u8]) -> Result<(), MemIsolateError> {
+fn error_if_buffer_is_empty(buffer: &[u8]) -> Result<(), MemIsolateError> {
     if buffer.is_empty() {
         let err = CallableStatusUnknown(CallableProcessDiedDuringExecution);
         error!("buffer unexpectedly empty, propagating {:?}", err);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -220,6 +220,16 @@ fn all_function_types() {
 
 #[rstest]
 #[timeout(TEST_TIMEOUT)]
+fn handle_large_result() {
+    let initial_string = "The quick brown fox jumps over the lazy dog";
+    let result = execute_in_isolated_process(|| {
+        initial_string.repeat(10000)
+    }).unwrap();
+    assert_eq!(result.len(), 10000 * initial_string.len());
+}
+
+#[rstest]
+#[timeout(TEST_TIMEOUT)]
 fn serialization_error() {
     // Custom type that implements Serialize but fails during serialization
     #[derive(Debug)]


### PR DESCRIPTION
This PR ensures we first call `read_all_of_child_result_pipe`, before `wait_for_child` which should fix #54.

Although a bit counterintuitive, we should read the data from the pipe before waiting for the child to exit, otherwise when the serialized data exceeds the pipe's buffer capacity, the child process will block indefinitely while trying to write, and the parent process will block indefinitely waiting for the child to exit, resulting in a deadlock.

This actually ends up simplifying our logic: we no longer check `read_all_of_child_result_pipe` for an empty buffer. If the buffer is empty, it means the child process exited unhappily, which will be immediately handled by `error_if_child_unhappy`. On the other hand, if we reach `deserialize_result`, we're guaranteed a non-empty buffer (as the buffer will contain the result of `serialize_result_or_error_value`, which is always non-empty).

I believe the only potential change in behavior is that a pipe read error would now supersede a child process exiting unhappily. I don't think this is a problem in practice.

I also found disabling mocking in the child thread's context seemed to fix #55. 