### PR TITLE
chore: Add test that covers the case when the user-defined callable panics

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -220,6 +220,26 @@ fn all_function_types() {
 
 #[rstest]
 #[timeout(TEST_TIMEOUT)]
+fn panic_in_child() {
+    #[allow(clippy::semicolon_if_nothing_returned)]
+    let error = execute_in_isolated_process(|| {
+        panic!("Panic in child");
+        #[allow(clippy::unused_unit)]
+        #[allow(unreachable_code)]
+        ()
+    })
+    .unwrap_err();
+    eprintln!("error: {error:?}",);
+    assert!(matches!(
+        error,
+        MemIsolateError::CallableStatusUnknown(
+            CallableStatusUnknownError::CallableProcessDiedDuringExecution
+        )
+    ));
+}
+
+#[rstest]
+#[timeout(TEST_TIMEOUT)]
 fn serialization_error() {
     // Custom type that implements Serialize but fails during serialization
     #[derive(Debug)]


### PR DESCRIPTION
Adds the test case discussed [here](https://github.com/brannondorsey/mem-isolate/pull/56#pullrequestreview-2782556692).