### PR TITLE
chore: Remove block that disables mocking for tests in the child process

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,10 +304,6 @@ where
                 span!(HIGHEST_LEVEL, "child").entered()
             };
 
-            #[cfg(test)]
-            // Disable mocking in the child process, fixes test failures on macOS
-            c::mock::disable_mocking();
-
             // NOTE: Fallible actions in the child must either serialize
             // and send their error over the pipe, or exit with a code
             // that can be inerpreted by the parent.


### PR DESCRIPTION
Not for merge right now. I mainly just want to see what MacOS tests will break.